### PR TITLE
Improve transition comment extraction

### DIFF
--- a/collective/auditlog/testing.py
+++ b/collective/auditlog/testing.py
@@ -1,13 +1,12 @@
-from plone.app.testing import TEST_USER_ID
-from Products.CMFCore.utils import getToolByName
-from plone.app.testing import setRoles
+# coding=utf-8
 from plone.app.testing import applyProfile
-from plone.app.testing import PLONE_FIXTURE
-from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
-from zope.configuration import xmlconfig
+from plone.app.testing import PloneSandboxLayer
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
 from plone.testing import z2
+from zope.configuration import xmlconfig
 
 try:
     from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_FIXTURE
@@ -31,10 +30,6 @@ class AuditLog(PloneSandboxLayer):
         # install into the Plone site
         applyProfile(portal, 'collective.auditlog:default')
         setRoles(portal, TEST_USER_ID, ('Member', 'Manager'))
-        # workflowTool = getToolByName(portal, 'portal_workflow')
-        # workflowTool.setDefaultChain('simple_publication_workflow')
-        # workflowTool.setChainForPortalTypes(('File',),
-        #                                     'simple_publication_workflow')
 
 
 AuditLog_FIXTURE = AuditLog()

--- a/collective/auditlog/tests/test_actions.py
+++ b/collective/auditlog/tests/test_actions.py
@@ -1,18 +1,20 @@
 # coding=utf-8
-from Products.Archetypes.event import ObjectEditedEvent
-from Products.Archetypes.event import ObjectInitializedEvent
-from zope.lifecycleevent import ObjectCreatedEvent
 from collective.auditlog.db import getSession
+from collective.auditlog.interfaces import IAuditLogSettings
 from collective.auditlog.models import Base
 from collective.auditlog.models import LogEntry
-from collective.auditlog.interfaces import IAuditLogSettings
 from collective.auditlog.testing import AuditLog_FUNCTIONAL_TESTING
-from plone.app.testing import TEST_USER_ID, TEST_USER_NAME
 from plone.app.testing import setRoles, login
+from plone.app.testing import TEST_USER_ID, TEST_USER_NAME
+from plone.app.contentrules.handlers import _status
 from plone.registry.interfaces import IRegistry
+from Products.Archetypes.event import ObjectEditedEvent
+from Products.Archetypes.event import ObjectInitializedEvent
+from Products.CMFCore.utils import getToolByName
 from tempfile import mkstemp
 from zope.component import getUtility
 from zope.event import notify
+from zope.lifecycleevent import ObjectCreatedEvent
 import os
 import transaction
 import unittest
@@ -23,15 +25,23 @@ class tempDb(object):
     registry_key = '{iface}.connectionstring'.format(
         iface=IAuditLogSettings.__identifier__
     )
+    session = None
 
     def __init__(self):
         _, self.tempfilename = mkstemp()
 
+    @property
+    def logs(self):
+        return self.session.query(LogEntry).all()
+
     def __enter__(self):
         self.registry = registry = getUtility(IRegistry)
-        registry[self.registry_key] = u'sqlite:///%s' % (self.tempfilename)
-        session = getSession()
-        Base.metadata.create_all(session.bind.engine)
+        registry[self.registry_key] = (
+            u'sqlite:///%s?check_same_thread=true' % (self.tempfilename)
+        )
+        self.session = getSession()
+        Base.metadata.create_all(self.session.bind.engine)
+        return self
 
     def __exit__(self, type, value, traceback):
         os.remove(self.tempfilename)
@@ -46,10 +56,6 @@ class TestActions(unittest.TestCase):
         self.request = self.layer['request'].clone()
         login(self.portal, TEST_USER_NAME)
         setRoles(self.portal, TEST_USER_ID, ['Manager'])
-
-    @property
-    def logs(self):
-        return getSession().query(LogEntry).all()
 
     def create_page(self, title='Page'):
         ''' Create a page and return it
@@ -66,37 +72,42 @@ class TestActions(unittest.TestCase):
             notify(ObjectInitializedEvent(obj))
         except AttributeError:
             notify(ObjectCreatedEvent(obj))
+        # We need to commit here so that _p_jar isn't None and move will work
+        transaction.savepoint(optimistic=True)
         return obj
 
+    def reset_rule_filter(self):
+        ''' If we want to execute a rule multiple times in the same test
+        we need to reset the rule filter, mocking a fresh request
+        '''
+        _status.rule_filter.reset()
+
     def test_add(self):
-        with tempDb():
+        with tempDb() as db:
             self.create_page()
-            self.assertEqual(self.logs[-1].action, 'added')
+            self.assertEqual(db.logs[-1].action, 'added')
 
     def test_unicode(self):
-        with tempDb():
+        with tempDb() as db:
             self.create_page(title='Pàge')
-            self.assertEqual(self.logs[-1].action, 'added')
+            self.assertEqual(db.logs[-1].action, 'added')
 
     def test_edit(self):
         self.create_page()
 
-        with tempDb():
+        with tempDb() as db:
             notify(ObjectEditedEvent(self.portal.page))
-            self.assertEqual(self.logs[-1].action, 'modified')
+            self.assertEqual(db.logs[-1].action, 'modified')
 
     @unittest.skip("The ObjectModifiedEvent seems not to be fired")
     def test_moved(self):
         self.create_page()
         self.portal.invokeFactory(type_name="Folder", id="folder",
                                   Title="folder")
-        with tempDb():
-            # We need to commit here so that _p_jar isn't None and move
-            # will work
-            transaction.savepoint(optimistic=True)
+        with tempDb() as db:
             cd = self.portal.manage_cutObjects('page')
             self.portal.folder.manage_pasteObjects(cd)
-            self.assertEqual(self.logs[-1].action, 'moved')
+            self.assertEqual(db.logs[-1].action, 'moved')
 
     def test_copied(self):
         self.create_page()
@@ -105,28 +116,50 @@ class TestActions(unittest.TestCase):
             id="folder",
             title="folder",
         )
-        with tempDb():
-            # We need to commit here so that _p_jar isn't None and move
-            # will work
-            transaction.savepoint(optimistic=True)
+        with tempDb() as db:
             cd = self.portal.manage_copyObjects('page')
             self.portal.folder.manage_pasteObjects(cd)
-            self.assertEqual(self.logs[-1].action, 'copied')
+            self.assertEqual(db.logs[-1].action, 'copied')
 
     @unittest.skip("The ObjectModifiedEvent seems not to be fired")
     def test_rename(self):
         self.create_page()
 
-        with tempDb():
-            # We need to commit here so that _p_jar isn't None and move
-            # will work
-            transaction.savepoint(optimistic=True)
+        with tempDb() as db:
             self.portal.manage_renameObject('page', 'page2')
-            self.assertEqual(self.logs[-1].action, 'rename')
+            self.assertEqual(db.logs[-1].action, 'rename')
 
     def test_delete(self):
         self.create_page()
 
-        with tempDb():
+        with tempDb() as db:
             self.portal.manage_delObjects(['page'])
-            self.assertEqual(self.logs[-1].action, 'removed')
+            self.assertEqual(db.logs[-1].action, 'removed')
+
+    def test_transition(self):
+        self.create_page()
+        pw = getToolByName(self.portal, 'portal_workflow')
+        with tempDb() as db:
+            # publish and ...
+            pw.doActionFor(
+                self.portal.page,
+                'publish',
+            )
+            self.assertEqual(db.logs[-1].action, u'workflow')
+            self.assertEqual(
+                db.logs[-1].info,
+                u"workflow transition: publish; comments: "
+            )
+            self.reset_rule_filter()
+            # ... retract the test page (adding a comment)
+            pw.doActionFor(
+                self.portal.page,
+                'retract',
+                comment="I've been commented ♥"
+            )
+            self.assertEqual(db.logs[-1].action, u'workflow')
+            self.assertEqual(
+                db.logs[-1].info,
+                u"workflow transition: retract; "
+                u"comments: I've been commented \u2665"
+            )

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,7 +4,8 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make action more robust on IActionSucceededEvent
+  [ale-rt]
 
 
 1.2.1 (2016-05-10)


### PR DESCRIPTION
Do not iterate on all the workflow history
Use get/getattr to avoid failures in case of very customized workflows and/or migrated content.

A test as been added