### PR TITLE
Skip retrieving rule when audit log is disabled completely.

### DIFF
--- a/collective/auditlog/action.py
+++ b/collective/auditlog/action.py
@@ -115,12 +115,15 @@ class AuditActionExecutor(object):
         return ''
 
     def __call__(self):
+        req = getRequest()
+        if req.environ.get('disable.auditlog', False):
+            return True
+
         event = self.event
         obj = event.object
         # order of those checks is important since some interfaces
         # base off the others
         rule = inspect.stack()[1][0].f_locals['self']
-        req = getRequest()
         registry = getUtility(IRegistry)
         trackWorkingCopies = registry['collective.auditlog.interfaces.IAuditLogSettings.trackworkingcopies']  # noqa
 

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,7 +4,9 @@ Changelog
 1.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Skip retrieving rule when audit log is disabled completely.
+  Improves performance.
+  [reinhardt]
 
 
 1.3.1 (2017-04-13)


### PR DESCRIPTION
When ```disable.auditlog``` is set then we don't need to look at which rule triggered the audit executor but can simply return, because ```canExecute()``` will return False anyway. This improves performance because retrieving the rule via ```inspect``` is relatively expensive.