### PR TITLE
Factored out getObjectInfo and addLogEntry.

### DIFF
--- a/collective/auditlog/utils.py
+++ b/collective/auditlog/utils.py
@@ -1,4 +1,10 @@
+from Products.CMFCore.utils import getToolByName
+from collective.auditlog import td
+from collective.auditlog.async import queueJob
+from datetime import datetime
 from plone.uuid.interfaces import IUUID
+from zope.component.hooks import getSite
+from zope.globalrequest import getRequest
 
 
 def getUID(context):
@@ -18,3 +24,53 @@ def getUID(context):
         return context.id
     except AttributeError:
         return ''
+
+
+def getHostname(request):
+    """
+    stolen from the developer manual
+    """
+
+    if "HTTP_X_FORWARDED_HOST" in request.environ:
+        # Virtual host
+        host = request.environ["HTTP_X_FORWARDED_HOST"]
+    elif "HTTP_HOST" in request.environ:
+        # Direct client request
+        host = request.environ["HTTP_HOST"]
+    else:
+        return None
+
+    # separate to domain name and port sections
+    host = host.split(":")[0].lower()
+
+    return host
+
+
+def getUser(context):
+    portal_membership = getToolByName(context, 'portal_membership')
+    return portal_membership.getAuthenticatedMember()
+
+
+def getObjectInfo(obj):
+    """ Get basic information about an object for logging.
+    This only includes information available on the object itself. Some fields
+    are missing because they depend on the event or rule that was triggered.
+    """
+    data = dict(
+        performed_on=datetime.utcnow(),
+        user=getUser(obj).getUserName(),
+        site_name=getHostname(getRequest()),
+        uid=getUID(obj),
+        type=obj.portal_type,
+        title=obj.Title(),
+        path='/'.join(obj.getPhysicalPath())
+    )
+    return data
+
+
+def addLogEntry(data):
+    tdata = td.get()
+    if not tdata.registered:
+        tdata.register()
+
+    queueJob(getSite(), **data)

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,7 +4,8 @@ Changelog
 1.3.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Factored out getObjectInfo and addLogEntry.
+  [reinhardt]
 
 
 1.3.2 (2018-07-11)


### PR DESCRIPTION
This makes it possible to add an audit log entry manually (without an event or a content rule) While still reusing existing code to get the object info and add the entry. We want to do this in a customer project when creating an object by copying from a template for performance resons and because all contained objects trigger an (unneeded) audit log entry as well.

Example call:
```
        data = getObjectInfo(obj)
        data['action'] = 'copied'
        addLogEntry(data)
```