### PR TITLE
Handle IWorkspaceCreatedFromTemplateEvent

### DIFF
--- a/collective/auditlog/action.py
+++ b/collective/auditlog/action.py
@@ -11,6 +11,11 @@ try:
 except ImportError:
     class IPloneFormGenField(Interface):
         pass
+try:
+    from ploneintranet.workspace.interfaces import IWorkspaceCreatedFromTemplateEvent  # noqa: E501
+except ImportError:
+    class IWorkspaceCreatedFromTemplateEvent(Interface):
+        pass
 
 from Products.Archetypes.interfaces import (
     IObjectInitializedEvent, IObjectEditedEvent, IBaseObject)
@@ -120,7 +125,8 @@ class AuditActionExecutor(object):
             action = 'removed'
         elif (IObjectInitializedEvent.providedBy(event) or
                 IObjectCreatedEvent.providedBy(event) or
-                IObjectAddedEvent.providedBy(event)):
+                IObjectAddedEvent.providedBy(event) or
+                IWorkspaceCreatedFromTemplateEvent.providedBy(event)):
             action = 'added'
         elif IObjectMovedEvent.providedBy(event):
             # moves can also be renames. Check the parent object

--- a/collective/auditlog/configure.zcml
+++ b/collective/auditlog/configure.zcml
@@ -104,4 +104,9 @@
     handler=".handlers.execute_event"
     />
 
+  <subscriber
+    for="ploneintranet.workspace.interfaces.IWorkspaceCreatedFromTemplateEvent"
+    handler=".handlers.execute_event"
+    />
+
 </configure>

--- a/collective/auditlog/configure.zcml
+++ b/collective/auditlog/configure.zcml
@@ -104,9 +104,4 @@
     handler=".handlers.execute_event"
     />
 
-  <subscriber
-    for="ploneintranet.workspace.interfaces.IWorkspaceCreatedFromTemplateEvent"
-    handler=".handlers.execute_event"
-    />
-
 </configure>

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,7 +4,8 @@ Changelog
 1.3.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Handle IWorkspaceCreatedFromTemplateEvent.
+  [reinhardt]
 
 
 1.3.3 (2018-07-12)


### PR DESCRIPTION
See https://github.com/quaive/ploneintranet/pull/2016

We need a subscriber directive and an entry in the case distinction so that the audit machinery is activated.