### PR TITLE
Allow easier customization

### DIFF
--- a/collective/auditlog/utils.py
+++ b/collective/auditlog/utils.py
@@ -1,9 +1,12 @@
-from Products.CMFCore.utils import getToolByName
+# coding=utf-8
+
 from collective.auditlog import td
 from collective.auditlog.async import queueJob
 from datetime import datetime
 from plone.uuid.interfaces import IUUID
+from Products.CMFCore.utils import getToolByName
 from zope.component.hooks import getSite
+from zope.deprecation import deprecate
 from zope.globalrequest import getRequest
 
 
@@ -26,6 +29,9 @@ def getUID(context):
         return ''
 
 
+@deprecate(  # remove in version 1.4
+    'Moved to collective.auditlog.action.AuditActionExecutor._getObjectInfo'
+)
 def getHostname(request):
     """
     stolen from the developer manual
@@ -46,11 +52,17 @@ def getHostname(request):
     return host
 
 
+@deprecate(  # remove in version 1.4
+    'Moved to collective.auditlog.action.AuditActionExecutor._getObjectInfo'
+)
 def getUser(context):
     portal_membership = getToolByName(context, 'portal_membership')
     return portal_membership.getAuthenticatedMember()
 
 
+@deprecate(  # remove in version 1.4
+    'Moved to collective.auditlog.action.AuditActionExecutor._getObjectInfo'
+)
 def getObjectInfo(obj):
     """ Get basic information about an object for logging.
     This only includes information available on the object itself. Some fields
@@ -68,6 +80,9 @@ def getObjectInfo(obj):
     return data
 
 
+@deprecate(  # remove in version 1.4
+    'Moved to collective.auditlog.action.AuditActionExecutor.addLogEntry'
+)
 def addLogEntry(data):
     tdata = td.get()
     if not tdata.registered:

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,7 +4,11 @@ Changelog
 1.3.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Deprecate some utility methods.
+  [ale-rt]
+- Added some memoized properties and methods to the `AuditActionExecutor` class
+  for easier customization
+  [ale-rt]
 
 
 1.3.3 (2018-07-12)


### PR DESCRIPTION
This splits the log entry calculation in to its own method that can be easily customized.
In addition it avoids inspecting the stack and the registry when it is not needed by using memoized properties.