### PR TITLE
Several improvements: vocab, more info

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 2.0.0a3 (unreleased)
 --------------------
 
+- Provide more object info in case for missing path, title or portal type information.
+  In the first case an object id is tried to used, in the second case the string representation of the Python object.
+  This way some more useable information is presented in case of deletion of content rules and the like.
+  [thet]
+
 - Add ``collective.auditlog.EventTypesVocabulary`` vocabulary.
   This one can be extended by providing a own implementation with ``<includeOverride>``.
   [thet]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.0.0a3 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Connection parameters should be optional.
+  [thet]
 
 
 2.0.0a2 (2020-03-19)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 2.0.0a3 (unreleased)
 --------------------
 
+- Add ``collective.auditlog.EventTypesVocabulary`` vocabulary.
+  This one can be extended by providing a own implementation with ``<includeOverride>``.
+  [thet]
+
 - Connection parameters should be optional.
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 2.0.0a3 (unreleased)
 --------------------
 
+- Fix ``is_installed`` method to also work with configuration set via ``zope.conf``.
+  [thet]
+
 - Provide more object info in case for missing path, title or portal type information.
   In the first case an object id is tried to used, in the second case the string representation of the Python object.
   This way some more useable information is presented in case of deletion of content rules and the like.

--- a/collective/auditlog/action.zcml
+++ b/collective/auditlog/action.zcml
@@ -39,4 +39,5 @@
       event="zope.interface.interfaces.IObjectEvent"
       schema=".action.IAuditAction"
       />
+
 </configure>

--- a/collective/auditlog/configure.zcml
+++ b/collective/auditlog/configure.zcml
@@ -138,6 +138,10 @@
       handler=".handlers.custom_event"
       />
 
+  <utility
+      component=".vocabularies.EventTypesVocabulary"
+      name="collective.auditlog.EventTypesVocabulary"
+      />
 
   <genericsetup:registerProfile
       name="default"

--- a/collective/auditlog/db.py
+++ b/collective/auditlog/db.py
@@ -30,13 +30,13 @@ def getEngine(conn_string=None, conn_parameters=None, req=None):
         if conn_string is None:
             conn_string = registry[
                 "collective.auditlog.interfaces.IAuditLogSettings.connectionstring"
-            ]  # noqa
+            ]
         if conn_parameters is None:
             conn_parameters = config.get("audit-connection-params", None)
         if conn_parameters is None:
-            conn_parameters = registry[
+            conn_parameters = registry.get(
                 "collective.auditlog.interfaces.IAuditLogSettings.connectionparameters"
-            ]  # noqa
+            )
         if not conn_parameters:
             conn_parameters = {}
         elif isinstance(conn_parameters, six.string_types):

--- a/collective/auditlog/db.py
+++ b/collective/auditlog/db.py
@@ -28,9 +28,11 @@ def getEngine(conn_string=None, conn_parameters=None, req=None):
         if conn_string is None:
             conn_string = config.get("audit-connection-string", None)
         if conn_string is None:
-            conn_string = registry[
+            conn_string = registry.get(
                 "collective.auditlog.interfaces.IAuditLogSettings.connectionstring"
-            ]
+            )
+        if not conn_string:
+            return
         if conn_parameters is None:
             conn_parameters = config.get("audit-connection-params", None)
         if conn_parameters is None:

--- a/collective/auditlog/interfaces.py
+++ b/collective/auditlog/interfaces.py
@@ -11,8 +11,8 @@ _ = MessageFactory("collective.auditlog")
 
 EVENT_TYPES = [
     (
-        "plone.app.iterate.interfaces.ICheckinEvent",
-        "A working copy has been checked in.",
+        "Products.CMFCore.interfaces.IActionSucceededEvent",
+        "A workflow action succeeded",
     ),
     (
         "plone.app.iterate.interfaces.IBeforeCheckoutEvent",
@@ -22,20 +22,29 @@ EVENT_TYPES = [
         "plone.app.iterate.interfaces.ICancelCheckoutEvent",
         "A working copy has been cancelled.",
     ),
-    ("zope.lifecycleevent.interfaces.IObjectMovedEvent", "An object has been moved"),
-    ("zope.lifecycleevent.interfaces.IObjectAddedEvent", "An object has been added"),
     (
-        "zope.lifecycleevent.interfaces.IObjectModifiedEvent",
-        "An object has been modified",
+        "plone.app.iterate.interfaces.ICheckinEvent",
+        "A working copy has been checked in.",
+    ),
+    (
+        "zope.lifecycleevent.interfaces.IObjectMovedEvent",  # noqa for black
+        "An object has been moved",
     ),
     (
         "zope.lifecycleevent.interfaces.IObjectRemovedEvent",
         "An object has been removed",
     ),
-    ("OFS.interfaces.IObjectClonedEvent", "An object has been copied"),
     (
-        "Products.CMFCore.interfaces.IActionSucceededEvent",
-        "A workflow action succeeded",
+        "zope.lifecycleevent.interfaces.IObjectModifiedEvent",
+        "An object has been modified",
+    ),
+    (
+        "zope.lifecycleevent.interfaces.IObjectAddedEvent",  # noqa for black
+        "An object has been added",
+    ),
+    (
+        "OFS.interfaces.IObjectClonedEvent",  # noqa for black
+        "An object has been copied",
     ),
     (
         "Products.PluggableAuthService.interfaces.events.IUserLoggedInEvent",

--- a/collective/auditlog/interfaces.py
+++ b/collective/auditlog/interfaces.py
@@ -3,60 +3,8 @@ from zope.i18nmessageid import MessageFactory
 from zope.interface import Interface
 from zope.interface.declarations import implementer
 from zope.interface.interface import Attribute
-from zope.schema.vocabulary import SimpleTerm
-from zope.schema.vocabulary import SimpleVocabulary
-
 
 _ = MessageFactory("collective.auditlog")
-
-EVENT_TYPES = [
-    (
-        "Products.CMFCore.interfaces.IActionSucceededEvent",
-        "A workflow action succeeded",
-    ),
-    (
-        "plone.app.iterate.interfaces.IBeforeCheckoutEvent",
-        "An object has been checked out.",
-    ),
-    (
-        "plone.app.iterate.interfaces.ICancelCheckoutEvent",
-        "A working copy has been cancelled.",
-    ),
-    (
-        "plone.app.iterate.interfaces.ICheckinEvent",
-        "A working copy has been checked in.",
-    ),
-    (
-        "zope.lifecycleevent.interfaces.IObjectMovedEvent",  # noqa for black
-        "An object has been moved",
-    ),
-    (
-        "zope.lifecycleevent.interfaces.IObjectRemovedEvent",
-        "An object has been removed",
-    ),
-    (
-        "zope.lifecycleevent.interfaces.IObjectModifiedEvent",
-        "An object has been modified",
-    ),
-    (
-        "zope.lifecycleevent.interfaces.IObjectAddedEvent",  # noqa for black
-        "An object has been added",
-    ),
-    (
-        "OFS.interfaces.IObjectClonedEvent",  # noqa for black
-        "An object has been copied",
-    ),
-    (
-        "Products.PluggableAuthService.interfaces.events.IUserLoggedInEvent",
-        "A user logged in",
-    ),
-    (
-        "Products.PluggableAuthService.interfaces.events.IUserLoggedOutEvent",
-        "A user logged out",
-    ),
-]
-
-EVENT_TYPES_VOCAB = [SimpleTerm(e[0], e[0], e[1]) for e in EVENT_TYPES]
 
 
 class IAuditLogSettings(Interface):
@@ -130,7 +78,7 @@ class IAuditLogSettings(Interface):
             ),
         ),
         default=[],
-        value_type=schema.Choice(vocabulary=SimpleVocabulary(EVENT_TYPES_VOCAB)),
+        value_type=schema.Choice(vocabulary='collective.auditlog.EventTypesVocabulary'),
     )
 
 

--- a/collective/auditlog/interfaces.py
+++ b/collective/auditlog/interfaces.py
@@ -102,7 +102,7 @@ class IAuditLogSettings(Interface):
                 u'E.g.: \'{"pool_recycle": 3600, "echo": true}\' '
             ),
         ),
-        required=True,
+        required=False,
         default=u"",
     )
 

--- a/collective/auditlog/tests/test_utils.py
+++ b/collective/auditlog/tests/test_utils.py
@@ -1,0 +1,79 @@
+# coding=utf-8
+from collective.auditlog.testing import AuditLog_INTEGRATION_TESTING
+from collective.auditlog import utils
+
+import unittest
+
+
+class TestUtils(unittest.TestCase):
+
+    layer = AuditLog_INTEGRATION_TESTING
+
+    def test_objectinfo(self):
+        info = utils.getObjectInfo(
+            type(
+                "TestClass",
+                (object,),
+                {
+                    "getPhysicalPath": lambda _self: ("", "path", "to", "ob"),
+                    "title": "test",
+                    "portal_type": "Test Type",
+                    "UID": "123",
+                },
+            )()
+        )
+        self.assertIsNotNone(info["performed_on"])
+        self.assertEqual(info["path"], "/path/to/ob")
+        self.assertEqual(info["type"], "Test Type")
+        self.assertEqual(info["title"], "test")
+        self.assertEqual(info["uid"], "123")
+        self.assertEqual(info["user"], "test-user")
+
+    def test_objectinfo_none(self):
+        info = utils.getObjectInfo(type("TestClass", (object,), {},)())
+        self.assertEqual(
+            info["type"],
+            "collective.auditlog.tests.test_utils.TestClass (Python class)",
+        )
+
+    def test_objectinfo_id(self):
+        info = utils.getObjectInfo(type("TestClass", (object,), {"id": "test id"})())
+        self.assertEqual(info["path"], "test id (id)")
+        self.assertEqual(info["title"], "test id (id)")
+
+    def test_objectinfo_uid(self):
+        info = utils.getObjectInfo(
+            type("TestClass", (object,), {"UID": "test UID attr"})()
+        )
+        self.assertEqual(info["uid"], "test UID attr")
+
+        info = utils.getObjectInfo(
+            type("TestClass", (object,), {"UID": "test UID callable"})()
+        )
+        self.assertEqual(info["uid"], "test UID callable")
+
+    def test_objectinfo_title(self):
+        info = utils.getObjectInfo(
+            type("TestClass", (object,), {"title": "test title attribute"})()
+        )
+        self.assertEqual(info["title"], "test title attribute")
+
+        info = utils.getObjectInfo(
+            type("TestClass", (object,), {"title": "test Title attribute"})()
+        )
+        self.assertEqual(info["title"], "test Title attribute")
+
+        info = utils.getObjectInfo(
+            type("TestClass", (object,), {"title": "test title callable"})()
+        )
+        self.assertEqual(info["title"], "test title callable")
+
+        info = utils.getObjectInfo(
+            type("TestClass", (object,), {"title": "test Title callable"})()
+        )
+        self.assertEqual(info["title"], "test Title callable")
+
+        info = utils.getObjectInfo(
+            type("TestClass", (object,), {"id": "test no title but id"})()
+        )
+        self.assertEqual(info["title"], "test no title but id (id)")

--- a/collective/auditlog/tests/test_utils.py
+++ b/collective/auditlog/tests/test_utils.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from collective.auditlog.testing import AuditLog_INTEGRATION_TESTING
 from collective.auditlog import utils
+from plone import api
 
 import unittest
 
@@ -77,3 +78,19 @@ class TestUtils(unittest.TestCase):
             type("TestClass", (object,), {"id": "test no title but id"})()
         )
         self.assertEqual(info["title"], "test no title but id (id)")
+
+    def test_is_installed(self):
+        """Should return true, if test setup was run properly.
+        """
+        self.assertTrue(utils.is_installed())
+
+    def test_not_installed(self):
+        """Should return false, if connection parameters are missing.
+        """
+        from collective.auditlog import db
+
+        db.engine = None  # resetting global engine
+        api.portal.set_registry_record(
+            "collective.auditlog.interfaces.IAuditLogSettings.connectionstring", u""
+        )
+        self.assertFalse(utils.is_installed())

--- a/collective/auditlog/utils.py
+++ b/collective/auditlog/utils.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from Acquisition import aq_base
 from Acquisition.interfaces import IAcquisitionWrapper
+from collective.auditlog import db
 from collective.auditlog import td
 from collective.auditlog.asyncqueue import queueJob
 from collective.auditlog.catalog import catalogEntry
@@ -12,7 +13,6 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import get_installer
 from Zope2 import app
 from zope.component import getUtility
-from zope.component import queryUtility
 from zope.component.hooks import getSite as getSiteHook
 from zope.event import notify
 from zope.globalrequest import getRequest
@@ -43,13 +43,8 @@ def is_installed():
         site = getSite()
         installer = get_installer(site)
         installed = installer.is_product_installed("collective.auditlog")
-        registry = queryUtility(IRegistry, context=site)
-        storage = (
-            registry.get("collective.auditlog.interfaces.IAuditLogSettings.storage")
-            if registry
-            else False
-        )
-        installed = installed and storage
+        storage = db.getEngine()
+        installed = installed and storage is not None
     except AttributeError:
         installed = False
     return installed

--- a/collective/auditlog/utils.py
+++ b/collective/auditlog/utils.py
@@ -1,5 +1,6 @@
 # coding=utf-8
-from Acquisition import aq_parent
+from Acquisition import aq_base
+from Acquisition.interfaces import IAcquisitionWrapper
 from collective.auditlog import td
 from collective.auditlog.asyncqueue import queueJob
 from collective.auditlog.catalog import catalogEntry
@@ -9,69 +10,12 @@ from plone.registry.interfaces import IRegistry
 from plone.uuid.interfaces import IUUID
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import get_installer
-from Products.CMFPlone.utils import pretty_title_or_id
 from Zope2 import app
 from zope.component import getUtility
 from zope.component import queryUtility
 from zope.component.hooks import getSite as getSiteHook
 from zope.event import notify
 from zope.globalrequest import getRequest
-
-
-def is_installed():
-    try:
-        site = getSite()
-        installer = get_installer(site)
-        installed = installer.is_product_installed("collective.auditlog")
-        registry = queryUtility(IRegistry, context=site)
-        installed = (
-            installed
-            and registry
-            and ("collective.auditlog.interfaces.IAuditLogSettings.storage" in registry)
-        )
-    except AttributeError:
-        installed = False
-    return installed
-
-
-def getUID(context):
-    uid = IUUID(context, None)
-    if uid is not None:
-        return uid
-
-    if hasattr(context, "UID"):
-        return context.UID()
-
-    try:
-        return "/".join(context.getPhysicalPath())
-    except AttributeError:
-        pass
-
-    try:
-        return context.id
-    except AttributeError:
-        return "unknown"
-
-
-def getHostname():
-    """
-    stolen from the developer manual
-    """
-    request = getRequest()
-    environ = getattr(request, "environ", {})
-    if "HTTP_X_FORWARDED_HOST" in environ:
-        # Virtual host
-        host = environ["HTTP_X_FORWARDED_HOST"]
-    elif "HTTP_HOST" in environ:
-        # Direct client request
-        host = environ["HTTP_HOST"]
-    else:
-        return None
-
-    # separate to domain name and port sections
-    host = host.split(":")[0].lower()
-
-    return host
 
 
 def getSite():
@@ -94,6 +38,52 @@ def getSite():
     return site
 
 
+def is_installed():
+    try:
+        site = getSite()
+        installer = get_installer(site)
+        installed = installer.is_product_installed("collective.auditlog")
+        registry = queryUtility(IRegistry, context=site)
+        storage = (
+            registry.get("collective.auditlog.interfaces.IAuditLogSettings.storage")
+            if registry
+            else False
+        )
+        installed = installed and storage
+    except AttributeError:
+        installed = False
+    return installed
+
+
+def getUID(context):
+    uid = IUUID(context, None)
+    if uid is not None:
+        return uid
+
+    uid = getattr(context, "UID", None)
+    return uid() if callable(uid) else uid
+
+
+def getHostname():
+    """Stolen from the developer manual.
+    """
+    request = getRequest()
+    environ = getattr(request, "environ", {})
+    if "HTTP_X_FORWARDED_HOST" in environ:
+        # Virtual host
+        host = environ["HTTP_X_FORWARDED_HOST"]
+    elif "HTTP_HOST" in environ:
+        # Direct client request
+        host = environ["HTTP_HOST"]
+    else:
+        return None
+
+    # separate to domain name and port sections
+    host = host.split(":")[0].lower()
+
+    return host
+
+
 def getUser():
     username = "unknown"
     try:
@@ -113,28 +103,44 @@ def getObjectInfo(obj):
     This only includes information available on the object itself. Some fields
     are missing because they depend on the event or rule that was triggered.
     """
-    obj_id = obj.id
-    if callable(obj_id):
-        obj_id = obj_id()
-    if not obj_id:
-        obj_id = "Zope"
-    data = dict(
-        performed_on=datetime.utcnow(),
-        user=getUser(),
-        site_name=getHostname(),
-        uid=getUID(obj),
-        type=getattr(obj, "portal_type", ""),
-        title=pretty_title_or_id(aq_parent(obj), obj),
-        path="/".join(obj.getPhysicalPath())
-        if getattr(obj, "getPhysicalPath", False)
-        else "/",
-    )
+    obj_base = obj
+    if IAcquisitionWrapper.providedBy(obj):
+        obj_base = aq_base(obj)
+
+    id = getattr(obj_base, "id", None)
+    id = "{} (id)".format(id) if id else None
+
+    path = id
+    if getattr(obj, "getPhysicalPath", False):
+        try:
+            path = "/".join(obj.getPhysicalPath())
+        except AttributeError:
+            pass
+
+    title = getattr(obj_base, "title", getattr(obj_base, "Title", id))
+    title = title() if callable(title) else title
+
+    portal_type = getattr(obj_base, "portal_type", None)
+    if not portal_type:
+        portal_type = "{}.{} (Python class)".format(
+            obj.__class__.__module__, obj.__class__.__name__
+        )
+
+    data = {
+        "path": path,
+        "performed_on": datetime.utcnow(),
+        "site_name": getHostname(),
+        "title": title,
+        "type": portal_type,
+        "uid": getUID(obj_base),
+        "user": getUser(),
+    }
     return data
 
 
 def addLogEntry(obj, data):
     # XXX getLogEntry sometime returns True, probably it should just return None
-    if not data or data == True:
+    if not data or data is True:
         return
     tdata = td.get()
     if not tdata.registered:

--- a/collective/auditlog/vocabularies.py
+++ b/collective/auditlog/vocabularies.py
@@ -1,0 +1,61 @@
+from zope.interface import provider
+from zope.schema.interfaces import IVocabularyFactory
+from zope.schema.vocabulary import SimpleTerm
+from zope.schema.vocabulary import SimpleVocabulary
+
+
+EVENT_TYPES = [
+    (
+        "Products.CMFCore.interfaces.IActionSucceededEvent",
+        "A workflow action succeeded",
+    ),
+    (
+        "plone.app.iterate.interfaces.IBeforeCheckoutEvent",
+        "An object has been checked out.",
+    ),
+    (
+        "plone.app.iterate.interfaces.ICancelCheckoutEvent",
+        "A working copy has been cancelled.",
+    ),
+    (
+        "plone.app.iterate.interfaces.ICheckinEvent",
+        "A working copy has been checked in.",
+    ),
+    (
+        "zope.lifecycleevent.interfaces.IObjectMovedEvent",  # noqa for black
+        "An object has been moved",
+    ),
+    (
+        "zope.lifecycleevent.interfaces.IObjectRemovedEvent",
+        "An object has been removed",
+    ),
+    (
+        "zope.lifecycleevent.interfaces.IObjectModifiedEvent",
+        "An object has been modified",
+    ),
+    (
+        "zope.lifecycleevent.interfaces.IObjectAddedEvent",  # noqa for black
+        "An object has been added",
+    ),
+    (
+        "OFS.interfaces.IObjectClonedEvent",  # noqa for black
+        "An object has been copied",
+    ),
+    (
+        "Products.PluggableAuthService.interfaces.events.IUserLoggedInEvent",
+        "A user logged in",
+    ),
+    (
+        "Products.PluggableAuthService.interfaces.events.IUserLoggedOutEvent",
+        "A user logged out",
+    ),
+]
+
+
+@provider(IVocabularyFactory)
+def EventTypesVocabulary(context):
+    """Event types which are available for audit logging.
+    Override this vocabulary if you want to extend or replace it.
+    """
+    items = [SimpleTerm(value=e[0], title=e[1]) for e in EVENT_TYPES]
+    return SimpleVocabulary(items)

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,12 @@ setup(
     namespace_packages=["collective"],
     include_package_data=True,
     zip_safe=False,
-    install_requires=["setuptools", "sqlalchemy", "plone.app.contentrules",],
+    install_requires=[
+        "setuptools",
+        "sqlalchemy",
+        "plone.app.contentrules",
+        "plone.api",
+    ],
     extras_require={
         "celery": ["collective.celery",],
         "test": [


### PR DESCRIPTION
- Provide more object info in case for missing path, title or portal type information.
  In the first case an object id is tried to used, in the second case the string representation of the Python object.
  This way some more useable information is presented in case of deletion of content rules and the like.
- Add ``collective.auditlog.EventTypesVocabulary`` vocabulary.
  This one can be extended by providing a own implementation with ``<includeOverride>``.
- Connection parameters should be optional.