### PR TITLE
editorconfig: Don't use inline comments.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,7 @@
 root = true
 
 
-[*]  # For All Files
+[*]
 # Unix-style newlines with a newline ending every file
 end_of_line = lf
 insert_final_newline = true

--- a/news/+fix-editorconfig.bugfix.rst
+++ b/news/+fix-editorconfig.bugfix.rst
@@ -1,0 +1,3 @@
+editorconfig: Don't use inline comments.
+Inline comments are invalid since editorconfig v0.15.0.
+[thet]


### PR DESCRIPTION
Inline comments are invalid since editorconfig v0.15.0.